### PR TITLE
Warning when deck shuffle indicates a lie

### DIFF
--- a/app/src/main/java/de/tobiundmario/secrethitlermobilecompanion/SHEvents/LegislativeSession.java
+++ b/app/src/main/java/de/tobiundmario/secrethitlermobilecompanion/SHEvents/LegislativeSession.java
@@ -32,7 +32,6 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 import de.tobiundmario.secrethitlermobilecompanion.R;
-import de.tobiundmario.secrethitlermobilecompanion.SHCards.CardDialog;
 import de.tobiundmario.secrethitlermobilecompanion.SHCards.CardSetupHelper;
 import de.tobiundmario.secrethitlermobilecompanion.SHClasses.Claim;
 import de.tobiundmario.secrethitlermobilecompanion.SHClasses.GameLog;
@@ -488,19 +487,8 @@ public class LegislativeSession extends GameEvent {
                             Log.v("LesiglativeSession Edit", "Fascist policies now at " + GameLog.fascistPolicies);
                         }
 
-                        if (newClaimEvent != null && !Claim.doClaimsFit(newClaimEvent.getPresidentClaim(), newClaimEvent.getChancellorClaim(), newClaimEvent.getPlayedPolicy())) {
-                            CardDialog.showMessageDialog(c, c.getString(R.string.dialog_mismatching_claims_title), c.getString(R.string.dialog_mismatching_claims_desc), c.getString(R.string.dialog_mismatching_claims_btn_continue), new Runnable() {
-                                @Override
-                                public void run() {
-                                    leaveSetupPhase(newClaimEvent, newVoteEvent);
-                                }
-                            }, c.getString(R.string.dialog_mismatching_claims_btn_cancel), null);
-                        } else {
-                            leaveSetupPhase(newClaimEvent, newVoteEvent);
-                            if (addTrackAction)
-                                GameLog.addTrackAction(LegislativeSession.this, false);
-                        }
-
+                        leaveSetupPhase(newClaimEvent, newVoteEvent);
+                        if (addTrackAction) GameLog.addTrackAction(LegislativeSession.this, false);
                     }
                 }
             });
@@ -645,6 +633,11 @@ public class LegislativeSession extends GameEvent {
             if(claimEvent.getPlayedPolicy() == Claim.LIBERAL) {
                 playedPolicyLogo.setImageDrawable(c.getDrawable(R.drawable.liberal_logo));
             } else playedPolicyLogo.setImageDrawable(c.getDrawable(R.drawable.fascist_logo));
+
+            LinearLayout ll_warning_claims = cardLayout.findViewById(R.id.warning_mismatching_claims);
+            if(!Claim.doClaimsFit(claimEvent.getPresidentClaim(), claimEvent.getChancellorClaim(), claimEvent.getPlayedPolicy())) {
+                ll_warning_claims.setVisibility(View.VISIBLE);
+            } else ll_warning_claims.setVisibility(View.GONE);
         }
 
         if(claimEvent != null && claimEvent.isVetoed()) {

--- a/app/src/main/res/drawable/ic_baseline_warning_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_warning_24.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#F2654B"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M1,21h22L12,2 1,21zM13,18h-2v-2h2v2zM13,14h-2v-4h2v4z"/>
+</vector>

--- a/app/src/main/res/layout/card_deck_shuffled.xml
+++ b/app/src/main/res/layout/card_deck_shuffled.xml
@@ -21,12 +21,11 @@
             android:layout_marginStart="21dp"
             android:layout_marginTop="8dp"
             android:layout_marginEnd="32dp"
-            android:layout_marginBottom="8dp"
             android:fontFamily="@font/germania_one"
             android:text="@string/deck_shuffled"
             android:textSize="22sp"
             android:textStyle="bold"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/warning_mismatching_deck"
             app:layout_constraintEnd_toStartOf="@+id/guideline"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -37,7 +36,7 @@
             android:layout_height="110dp"
             android:layout_marginStart="16dp"
             android:alpha="0.7"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/warning_mismatching_deck"
             app:layout_constraintStart_toEndOf="@+id/title"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/icon_fpolicy" />
@@ -50,7 +49,7 @@
             android:text="11"
             android:textColor="#000000"
             android:textSize="45sp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBottomOf="@+id/img_fascist_policy"
             app:layout_constraintEnd_toEndOf="@+id/img_fascist_policy"
             app:layout_constraintStart_toStartOf="@+id/img_fascist_policy"
             app:layout_constraintTop_toTopOf="@+id/img_fascist_policy" />
@@ -61,7 +60,6 @@
             android:layout_height="110dp"
             android:layout_marginStart="8dp"
             android:alpha="0.7"
-            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toEndOf="@+id/img_fascist_policy"
             app:layout_constraintTop_toTopOf="parent"
             app:srcCompat="@drawable/icon_lpolicy" />
@@ -74,7 +72,7 @@
             android:text="11"
             android:textColor="#000000"
             android:textSize="45sp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBottomOf="@+id/img_liberal_policy"
             app:layout_constraintEnd_toEndOf="@+id/img_liberal_policy"
             app:layout_constraintStart_toStartOf="@+id/img_liberal_policy"
             app:layout_constraintTop_toTopOf="@+id/img_liberal_policy" />
@@ -85,6 +83,38 @@
             android:layout_height="wrap_content"
             android:orientation="vertical"
             app:layout_constraintGuide_percent="0.5" />
+
+        <LinearLayout
+            android:id="@+id/warning_mismatching_deck"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="horizontal"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/img_liberal_policy">
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:layout_gravity="center"
+                android:layout_weight="1"
+                app:srcCompat="@drawable/ic_baseline_warning_24" />
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_weight="4"
+                android:fontFamily="@font/comfortaa_light"
+                android:text="@string/message_claims_not_matching_with_deck" />
+        </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/app/src/main/res/layout/card_deck_shuffled.xml
+++ b/app/src/main/res/layout/card_deck_shuffled.xml
@@ -91,8 +91,9 @@
             android:layout_marginStart="16dp"
             android:layout_marginEnd="16dp"
             android:layout_marginBottom="8dp"
+            android:gravity="center"
             android:orientation="horizontal"
-            android:visibility="gone"
+            android:visibility="visible"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -100,10 +101,9 @@
 
             <ImageView
                 android:id="@+id/imageView"
-                android:layout_width="30dp"
+                android:layout_width="25dp"
                 android:layout_height="30dp"
                 android:layout_gravity="center"
-                android:layout_weight="1"
                 app:srcCompat="@drawable/ic_baseline_warning_24" />
 
             <TextView
@@ -111,7 +111,6 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="10dp"
-                android:layout_weight="4"
                 android:fontFamily="@font/comfortaa_light"
                 android:text="@string/message_claims_not_matching_with_deck" />
         </LinearLayout>

--- a/app/src/main/res/layout/card_legislative_session.xml
+++ b/app/src/main/res/layout/card_legislative_session.xml
@@ -98,13 +98,14 @@
             app:layout_constraintTop_toTopOf="@+id/chanc_name" />
 
         <LinearLayout
+            android:id="@+id/ll_played_policy"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="8dp"
             android:gravity="center"
             android:orientation="horizontal"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/warning_mismatching_claims"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/chanc_name">
@@ -127,6 +128,37 @@
                 android:cropToPadding="false"
                 android:scaleType="fitCenter"
                 app:srcCompat="@drawable/fascist_logo" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/warning_mismatching_claims"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="visible"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent">
+
+            <ImageView
+                android:id="@+id/imageView"
+                android:layout_width="25dp"
+                android:layout_height="30dp"
+                android:layout_gravity="center"
+                app:srcCompat="@drawable/ic_baseline_warning_24" />
+
+            <TextView
+                android:id="@+id/textView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginStart="10dp"
+                android:fontFamily="@font/comfortaa_light"
+                android:text="@string/dialog_mismatching_claims_title" />
         </LinearLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,4 +159,5 @@
     <string name="snackbar_message_player_removed">Player has been removed</string>
     <string name="title_voting_outcome">Vote outcome:</string>
     <string name="title_claims">Claims:</string>
+    <string name="message_claims_not_matching_with_deck">The specified claims do not match with the shuffled deck. Did someone lie?</string>
 </resources>


### PR DESCRIPTION
In case the preceding claims do not match, a warning is displayed on the cardView. Fixes #12 